### PR TITLE
Add insert at each line

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This keymap includes shortcuts for all the official extension and replaces codem
 - lint
 - search
 
+The keymap is based on the following:
+- [Windows](https://code.visualstudio.com/shortcuts/keyboard-shortcuts-windows.pdf)
+- [Mac](https://code.visualstudio.com/shortcuts/keyboard-shortcuts-macos.pdf)
+- [Linux](https://code.visualstudio.com/shortcuts/keyboard-shortcuts-linux.pdf)
+
 ### Usage
 ```ts
 import { EditorView, keymap } from '@codemirror/view';
@@ -42,7 +47,6 @@ new EditorView({
 ```
 
 ### Missing features
-- Insert cursor at end of each line selected Shift+Alt+I
 - Scroll Line Down	Ctrl+Down
 - Scroll Line Up	Ctrl+Up
 - Scroll Page Down	Alt+PageDown

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ import {
   startCompletion,
 } from '@codemirror/autocomplete';
 import { nextDiagnostic, openLintPanel } from '@codemirror/lint';
-import { addCursorDown, addCursorUp } from './multiCursor';
+import { addCursorAtEachSelectionLine, addCursorDown, addCursorUp } from './multiCursor';
 
 export const vscodeKeymap: ReadonlyArray<KeyBinding> = [
   { key: 'Ctrl-Space', run: startCompletion },
@@ -174,6 +174,11 @@ export const vscodeKeymap: ReadonlyArray<KeyBinding> = [
     linux: 'Shift-Alt-ArrowDown',
     run: addCursorDown,
     preventDefault: true,
+  },
+
+  {
+    key: 'Shift-Alt-i',
+    run: addCursorAtEachSelectionLine,
   },
 
   { key: 'Mod-End', run: cursorDocEnd, shift: selectDocEnd },


### PR DESCRIPTION
This PR adds a command that allows users to create cursors per each selected line. One behavior to note is that if the selection doesn't cover the line, the cursor is inserted at the end of the selection instead.

[#]:fel

---
This diff is part of a [fel stack](https://github.com/zabot/fel)
<pre>
* <a href="1">#1 Add insert at each line</a>
* <a href="4">#4 Add insert cursor up/down commands</a>
* <a href="2">#2 Add codemirror/state to peer deps</a>
* <a href="3">#3 Fix copy-line-up/down existing on linux</a>
* master
</pre>
