### PR TITLE
Fix copy-line-up/down existing on linux

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,8 +202,8 @@ export const vscodeKeymap: ReadonlyArray<KeyBinding> = [
   { key: 'Shift-Mod-k', run: deleteLine },
   { key: 'Alt-ArrowDown', run: moveLineDown },
   { key: 'Alt-ArrowUp', run: moveLineUp },
-  { key: 'Shift-Alt-ArrowDown', run: copyLineDown },
-  { key: 'Shift-Alt-ArrowUp', run: copyLineUp },
+  { win: 'Shift-Alt-ArrowDown', mac: 'Shift-Alt-ArrowDown', run: copyLineDown },
+  { win: 'Shift-Alt-ArrowUp', mac: 'Shift-Alt-ArrowUp', run: copyLineUp },
 
   { key: 'Mod-l', run: selectLine, preventDefault: true },
   { key: 'Shift-Mod-\\', run: cursorMatchingBracket },


### PR DESCRIPTION
Turns out linux users aren't blessed with such shortcut in vscode. I think it's because of how ubuntu captures the keybinding.

I changed the code to remove linux :(

[#]:fel

---
This diff is part of a [fel stack](https://github.com/zabot/fel)
<pre>
* <a href="1">#1 Add insert at each line</a>
* <a href="4">#4 Add insert cursor up/down commands</a>
* <a href="2">#2 Add codemirror/state to peer deps</a>
* <a href="3">#3 Fix copy-line-up/down existing on linux</a>
* master
</pre>
