### PR TITLE
Add insert cursor up/down commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ new EditorView({
 
 ### Missing features
 - Insert cursor at end of each line selected Shift+Alt+I
-- Insert Cursor Below Ctrl+Alt+Down
-- Insert Cursor Above Ctrl+Alt+Up
 - Scroll Line Down	Ctrl+Down
 - Scroll Line Up	Ctrl+Up
 - Scroll Page Down	Alt+PageDown

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ import {
   startCompletion,
 } from '@codemirror/autocomplete';
 import { nextDiagnostic, openLintPanel } from '@codemirror/lint';
+import { addCursorDown, addCursorUp } from './multiCursor';
 
 export const vscodeKeymap: ReadonlyArray<KeyBinding> = [
   { key: 'Ctrl-Space', run: startCompletion },
@@ -83,7 +84,7 @@ export const vscodeKeymap: ReadonlyArray<KeyBinding> = [
   { key: 'PageUp', run: moveCompletionSelection(false, 'page') },
   { key: 'Enter', run: acceptCompletion },
   { key: 'Tab', run: acceptCompletion },
-  
+
   { key: 'Mod-f', run: openSearchPanel, scope: 'editor search-panel' },
   { key: 'Escape', run: closeSearchPanel, scope: 'editor search-panel' },
   { key: 'Alt-Enter', run: selectMatches, scope: 'editor search-panel' },
@@ -160,6 +161,19 @@ export const vscodeKeymap: ReadonlyArray<KeyBinding> = [
     mac: 'Cmd-ArrowRight',
     run: cursorLineBoundaryForward,
     shift: selectLineBoundaryForward,
+  },
+
+  {
+    key: 'Mod-Alt-ArrowUp',
+    linux: 'Shift-Alt-ArrowUp',
+    run: addCursorUp,
+    preventDefault: true,
+  },
+  {
+    key: 'Mod-Alt-ArrowDown',
+    linux: 'Shift-Alt-ArrowDown',
+    run: addCursorDown,
+    preventDefault: true,
   },
 
   { key: 'Mod-End', run: cursorDocEnd, shift: selectDocEnd },

--- a/src/multiCursor.ts
+++ b/src/multiCursor.ts
@@ -1,0 +1,21 @@
+import { Command, EditorView } from '@codemirror/view';
+import { EditorSelection } from '@codemirror/state';
+
+const createAddCursor =
+  (direction: 'up' | 'down'): Command =>
+  (view) => {
+    const forward = direction === 'down';
+
+    const selection = view.state.selection;
+
+    for (const r of selection.ranges) {
+      selection.addRange(view.moveVertically(r, forward));
+    }
+
+    view.dispatch({ selection });
+
+    return true;
+  };
+
+export const addCursorUp = createAddCursor('up');
+export const addCursorDown = createAddCursor('down');


### PR DESCRIPTION
Adds a very important shortcut that adds a cursor on the next/prev line.

[#]:fel

---
This diff is part of a [fel stack](https://github.com/zabot/fel)
<pre>
* <a href="1">#1 Add insert at each line</a>
* <a href="4">#4 Add insert cursor up/down commands</a>
* <a href="2">#2 Add codemirror/state to peer deps</a>
* <a href="3">#3 Fix copy-line-up/down existing on linux</a>
* master
</pre>
