### PR TITLE
Fix multi-cursor selection logic

### DIFF
--- a/src/multiCursor.ts
+++ b/src/multiCursor.ts
@@ -6,10 +6,10 @@ const createAddCursor =
   (view) => {
     const forward = direction === 'down';
 
-    const selection = view.state.selection;
+    let selection = view.state.selection;
 
     for (const r of selection.ranges) {
-      selection.addRange(view.moveVertically(r, forward));
+      selection = selection.addRange(view.moveVertically(r, forward));
     }
 
     view.dispatch({ selection });
@@ -33,9 +33,9 @@ export const addCursorAtEachSelectionLine: Command = (view) => {
       const anchor = Math.min(line.to, r.to);
 
       if (selection) {
-        selection.addRange(EditorSelection.range(anchor, anchor));
+        selection = selection.addRange(EditorSelection.range(anchor, anchor));
       } else {
-        EditorSelection.single(anchor);
+        selection = EditorSelection.single(anchor);
       }
 
       pos = line.to + 1;


### PR DESCRIPTION
# Why

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->

It no work

# What changed

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

`selection.addRange(newRange)` actually returns a new selection, rather than modifying the existing one. Now we actually assign the new selection to `selection`

# Test plan

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->

1) Test adding cursor above/below (Shift+Alt+Up/Down)
1) Test adding multiple cursors in the selection (Shift+Alt+i)
